### PR TITLE
Fix warnings issued by travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-# http://docs.travis-ci.com/user/workers/container-based-infrastructure/
-sudo: false
-
 language: php
+
+os:
+  - linux
 
 # Travis support wrote "Ubuntu 14.04 reached EOL on April 30th, 2019,
 # ... we've been slowly rolling out changes to make Xenial builds ..."
@@ -10,7 +10,7 @@ language: php
 services:
   - mysql
 
-matrix:
+jobs:
   fast_finish: true
   include:
     - env: DB=mysql; MW=REL1_32; TYPE=coverage; PHPUNIT=6.5.*


### PR DESCRIPTION
This PR is made in reference to: #

This PR addresses or contains:
- root: deprecated key sudo (no effect)
- root: key matrix is an alias for jobs, using jobs
- root: missing os, using the default linux

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
