### PR TITLE
Use strict semantic versioning for the version number

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,11 +1,10 @@
 This file contains the RELEASE-NOTES of the **Semantic Image Caption** (a.k.a. SIC) extension.
 
-### 7.0.0
+### 2.0.0
 
 Released on TBD.
 
 - Raised the minimum supported Semantic MediaWiki version to 7.0 and MediaWiki to 1.43.
-- The version number jumps from 1.x to 7.0 to track the major release of Semantic MediaWiki that the extension targets; the intermediate major numbers (2.x–6.x) are skipped.
 - Updated the internal usage of Semantic MediaWiki data-item classes to their Semantic MediaWiki 7.0 namespaced names.
 - Fixed caption generation from a `Monolingual text` property silently failing when the monolingual text lookup service is unavailable.
 - Modernized extension registration: removed the procedural `SemanticImageCaption.php` entry point, its `initExtension` callback, and the empty extension function in favour of native `extension.json` declarations. The internal `SMW_IMAGECAPTION_VERSION` constant has been removed.

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "7.0.0-dev"
+			"dev-master": "2.x-dev"
 		}
 	},
 	"config": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticImageCaption",
-	"version": "7.0.0-alpha",
+	"version": "2.0.0-alpha",
 	"author": [
        	"James Hong Kong",
 		"..."


### PR DESCRIPTION
## Summary

Adopt semantic versioning for the **SemanticImageCaption** version number. Versioning the extension independently of Semantic MediaWiki lets it introduce its own breaking changes mid-cycle — between Semantic MediaWiki major releases — instead of holding them to realign its major with the next Semantic MediaWiki major.

This sets the version to the extension's own next major, `2.0.0-alpha` (branch-alias `2.x-dev`), rather than tracking the Semantic MediaWiki major. The `SemanticMediaWiki >= 7.0` requirement (the Semantic MediaWiki version this release targets) is unchanged.

## Changes

- `extension.json`: version → `2.0.0-alpha`
- `composer.json`: `extra.branch-alias.dev-master` → `2.x-dev`
- `RELEASE-NOTES.md`: heading → `2.0.0`, and drop the note that described the version tracking / mirroring the Semantic MediaWiki major
- `@since 7.0.0` docblocks updated to `@since 2.0.0` where present
